### PR TITLE
Added optional color support to lights

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,15 @@ light:
     name: 'Light 1'
     initial_value: 'on'
     initial_brightness: 100
+    support_color: true
+    initial_color: [0,255]
+    support_color_temp: true
+    initial_color_temp: 255
+    support_white_value: true
+    initial_white_value: 240
 ```
+
+Only `name` is required. Use the `support_*` options to allow the light to have color and temperature properties. Use `initial_*` to set the default values. `initial_color` is `[hue (0-360), saturation (0-100)]`
 
 To add multiple components repeat the platform.
 

--- a/custom_components/virtual/light.py
+++ b/custom_components/virtual/light.py
@@ -115,7 +115,7 @@ class VirtualLight(LightEntity):
             self._ct = None
             
         ct = kwargs.get(ATTR_COLOR_TEMP, None)
-        if ct is not None  and self._features & SUPPORT_COLOR_TEMP:
+        if ct is not None and self._features & SUPPORT_COLOR_TEMP:
             self._color_mode = "ct"
             self._ct = ct
             self._hs_color = None
@@ -125,7 +125,7 @@ class VirtualLight(LightEntity):
             self._brightness = brightness
 
         white = kwargs.get(ATTR_WHITE_VALUE, None)
-        if white is not None & SUPPORT_WHITE_VALUE:
+        if white is not None and self._features & SUPPORT_WHITE_VALUE:
             self._white = white
 
         _LOGGER.info("turn_on: {}".format(pprint.pformat(kwargs)))

--- a/custom_components/virtual/light.py
+++ b/custom_components/virtual/light.py
@@ -11,7 +11,13 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR,
+    ATTR_WHITE_VALUE,
     SUPPORT_BRIGHTNESS,
+    SUPPORT_COLOR,
+    SUPPORT_COLOR_TEMP,
+    SUPPORT_WHITE_VALUE,
     LightEntity,
 )
 from homeassistant.helpers.config_validation import (PLATFORM_SCHEMA)
@@ -24,14 +30,32 @@ DEPENDENCIES = [COMPONENT_DOMAIN]
 CONF_NAME = "name"
 CONF_INITIAL_VALUE = "initial_value"
 CONF_INITIAL_BRIGHTNESS = "initial_brightness"
+CONF_SUPPORT_COLOR = "support_color"
+CONF_INITIAL_COLOR = "initial_color"
+CONF_SUPPORT_COLOR_TEMP = "support_color_temp"
+CONF_INITIAL_COLOR_TEMP = "initial_color_temp"
+CONF_SUPPORT_WHITE_VALUE = "support_white_value"
+CONF_INITIAL_WHITE_VALUE = "initial_white_value"
 
-DEFAULT_INITIAL_VALUE = "off"
-DEFAULT_INITIAL_BRIGHTNESS = "100"
+DEFAULT_INITIAL_VALUE = "on"
+DEFAULT_INITIAL_BRIGHTNESS = 255
+DEFAULT_SUPPORT_COLOR = False
+DEFAULT_INITIAL_COLOR = [0,100]
+DEFAULT_SUPPORT_COLOR_TEMP = False
+DEFAULT_INITIAL_COLOR_TEMP = 240
+DEFAULT_SUPPORT_WHITE_VALUE = False
+DEFAULT_INITIAL_WHITE_VALUE = 240
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_NAME): cv.string,
     vol.Optional(CONF_INITIAL_VALUE, default=DEFAULT_INITIAL_VALUE): cv.string,
-    vol.Optional(CONF_INITIAL_BRIGHTNESS, default=DEFAULT_INITIAL_BRIGHTNESS): cv.string,
+    vol.Optional(CONF_INITIAL_BRIGHTNESS, default=DEFAULT_INITIAL_BRIGHTNESS): cv.byte,
+    vol.Optional(CONF_SUPPORT_COLOR, default=DEFAULT_SUPPORT_COLOR): cv.boolean,
+    vol.Optional(CONF_INITIAL_COLOR, default=DEFAULT_INITIAL_COLOR): cv.ensure_list,
+    vol.Optional(CONF_SUPPORT_COLOR_TEMP, default=DEFAULT_SUPPORT_COLOR_TEMP): cv.boolean,
+    vol.Optional(CONF_INITIAL_COLOR_TEMP, default=DEFAULT_INITIAL_COLOR_TEMP): cv.byte,
+    vol.Optional(CONF_SUPPORT_WHITE_VALUE, default=DEFAULT_SUPPORT_WHITE_VALUE): cv.boolean,
+    vol.Optional(CONF_INITIAL_WHITE_VALUE, default=DEFAULT_INITIAL_WHITE_VALUE): cv.byte,
 })
 
 
@@ -48,6 +72,23 @@ class VirtualLight(LightEntity):
         self._unique_id = self._name.lower().replace(' ', '_')
         self._state = config.get(CONF_INITIAL_VALUE)
         self._brightness = config.get(CONF_INITIAL_BRIGHTNESS)
+        self._features = SUPPORT_BRIGHTNESS
+
+        self._hs_color = None
+        self._ct = None
+        self._white =  None
+        self._color_mode = None
+        if config.get(CONF_SUPPORT_COLOR):
+            self._features |= SUPPORT_COLOR
+            self._hs_color = config.get(CONF_INITIAL_COLOR)
+            self._color_mode = "hs"
+        if config.get(CONF_SUPPORT_COLOR_TEMP):
+            self._features |= SUPPORT_COLOR_TEMP
+            self._ct = config.get(CONF_INITIAL_COLOR_TEMP)
+            self._color_mode = "ct"
+        if config.get(CONF_SUPPORT_WHITE_VALUE):
+            self._features |= SUPPORT_WHITE_VALUE
+            self._white =  config.get(CONF_INITIAL_WHITE_VALUE)
         _LOGGER.info('VirtualLight: %s created', self._name)
 
     @property
@@ -63,13 +104,29 @@ class VirtualLight(LightEntity):
     @property
     def supported_features(self):
         """Flag features that are supported."""
-        return SUPPORT_BRIGHTNESS
+        return self._features
 
     def turn_on(self, **kwargs):
         """Turn the light on."""
+        hs_color = kwargs.get(ATTR_HS_COLOR, None)
+        if hs_color is not None and self._features & SUPPORT_COLOR:
+            self._color_mode = "hs"
+            self._hs_color = hs_color
+            self._ct = None
+            
+        ct = kwargs.get(ATTR_COLOR_TEMP, None)
+        if ct is not None  and self._features & SUPPORT_COLOR_TEMP:
+            self._color_mode = "ct"
+            self._ct = ct
+            self._hs_color = None
+
         brightness = kwargs.get(ATTR_BRIGHTNESS, None)
         if brightness is not None:
             self._brightness = brightness
+
+        white = kwargs.get(ATTR_WHITE_VALUE, None)
+        if white is not None & SUPPORT_WHITE_VALUE:
+            self._white = white
 
         _LOGGER.info("turn_on: {}".format(pprint.pformat(kwargs)))
         self._state = "on"
@@ -85,6 +142,25 @@ class VirtualLight(LightEntity):
         return self._brightness
 
     @property
+    def hs_color(self) -> tuple:
+        """Return the hs color value."""
+        if self._color_mode == "hs":
+            return self._hs_color
+        return None
+
+    @property
+    def color_temp(self) -> int:
+        """Return the CT color temperature."""
+        if self._color_mode == "ct":
+            return self._ct
+        return None
+
+    @property
+    def white_value(self) -> int:
+        """Return the white value of this light between 0..255."""
+        return self._white
+
+    @property
     def device_state_attributes(self):
         """Return the state attributes."""
 
@@ -92,6 +168,10 @@ class VirtualLight(LightEntity):
             name: value for name, value in (
                 ('friendly_name', self._name),
                 ('brightness', self._brightness),
+                ('hs_color', self._hs_color),
+                ('white_value', self._white),
+                ('color_temp', self._ct),
+                ('color_mode', self._color_mode),
             ) if value is not None
         }
 


### PR DESCRIPTION
Added support for color for lights. It is based on how the core homeassistant Demo integration stores the same values. It is optional and can be turned on in the config file along with initial values.