### PR TITLE
Save tracker state

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Virtual components for testing Home Assistant systems.
 ### **Breaking Changes**
 
 I've added persistent support to `binary_sensor`, `fan`, `light`, `lock`,
-`sensor` and `switch` and `device_tracker`. The persistent saving of state is
+`sensor`, `switch` and `device_tracker`. The persistent saving of state is
 turned *on* by default. If you do not want this set `persistent: False` in the
 entity configuration.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Virtual components for testing Home Assistant systems.
 ### **Breaking Changes**
 
 I've added persistent support to `binary_sensor`, `fan`, `light`, `lock`,
-`sensor` and `switch`. The persistent saving of state is turned *on* by default.
-If you do not want this set `persistent: False` in the entity configuration.
+`sensor` and `switch` and `device_tracker`. The persistent saving of state is
+turned *on* by default. If you do not want this set `persistent: False` in the
+entity configuration.
 
 
 ## Table Of Contents
@@ -194,9 +195,9 @@ lock:
 ```
 
 - Persistent Configuration
-    - `initial_availibilty`: optional, default `True`; is device available at start up
-    - `initial_value`: optional, default `locked`; any other value will result in the lock
-      being unlocked at start up
+  - `initial_availibilty`: optional, default `True`; is device available at start up
+  - `initial_value`: optional, default `locked`; any other value will result in the lock
+    being unlocked at start up
 - Per Run Configuration
   - `name`: _required_; device name
   - `locking_time`: optional, default `0` seconds; any positive value will result in a
@@ -235,9 +236,32 @@ To add a virtual device tracker use the following:
 device_tracker:
   - platform: virtual
     devices:
+      - name: virtual_user1
+        peristent: True
+        location: home
+      - name: virtual_user2
+        peristent: False
+        location: not_home
+```
+
+Only `name` is required.
+- `persistent`: default `True`; if `True` then entity location is remembered
+  across restarts otherwise entity always starts at `location`
+- `location`: default `home`; this sets the device location when it is created
+  or if the device is not `persistent`
+
+Use the `device_tracker.see` service to change device locations.
+
+
+#### Old Style Configuration
+The old style configuration will still work. They will be moved to home on
+initial creation and their location will survive restarts.
+
+```yaml
+device_tracker:
+  - platform: virtual
+    devices:
       - virtual_user1
       - virtual_user2
 ```
 
-They will be moved to home on reboot. Use the `device_tracker.see` service to
-change device locations.

--- a/changelog
+++ b/changelog
@@ -1,3 +1,4 @@
+0.8.0a3: save device tracker location
 0.8.0a2: added locking/unlocking state to locks
 0.8.0a1: Added state restore to all but device tracker.
             [thanks to SergeyPomelov for the push on this]

--- a/custom_components/virtual/__init__.py
+++ b/custom_components/virtual/__init__.py
@@ -16,7 +16,7 @@ from .const import (
     COMPONENT_SERVICES
 )
 
-__version__ = '0.8.0a2'
+__version__ = '0.8.0a3'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/virtual/device_tracker.py
+++ b/custom_components/virtual/device_tracker.py
@@ -4,22 +4,74 @@ This component provides support for a virtual device tracker.
 """
 
 import logging
+import json
 
 from homeassistant.const import CONF_DEVICES, STATE_HOME
+from homeassistant.components.device_tracker import DOMAIN
+from homeassistant.helpers.event import async_track_state_change_event
 from . import COMPONENT_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = [COMPONENT_DOMAIN]
+STATE_FILE = "/config/.storage/virtual.restore_state"
+
+tracker_states = {}
+
+
+def _write_state():
+    global tracker_states
+    try:
+        with open(STATE_FILE, 'w') as f:
+            json.dump(tracker_states, f)
+    except:
+        pass
+
+
+def _state_changed(event):
+    entity_id = event.data.get('entity_id', None)
+    new_state = event.data.get('new_state', None)
+    if entity_id is None or new_state is None:
+        _LOGGER.info(f'state changed error')
+        return
+
+    # update database
+    _LOGGER.info(f"moving {entity_id} to {new_state.state}")
+    global tracker_states
+    tracker_states[entity_id] = new_state.state
+    _write_state()
+
+
+def _shutting_down(event):
+    _LOGGER.info(f'shutting down {event}')
+    _write_state()
 
 
 async def async_setup_scanner(hass, config, async_see, _discovery_info=None):
     """Set up the virtual tracker."""
 
-    # Move all configured devices home
-    for dev_id in config[CONF_DEVICES]:
-        _LOGGER.info("moving {} home".format(dev_id))
-        see_args = {"dev_id": dev_id, "source_type": COMPONENT_DOMAIN, "location_name": STATE_HOME}
+    # parse out the last known state
+    global tracker_states
+    try:
+        with open(STATE_FILE, 'r') as f:
+            tracker_states = json.load(f)
+    except:
+        pass
+
+    for device in config[CONF_DEVICES]:
+        entity_id = f"{DOMAIN}.{device}"
+        state = tracker_states.get(entity_id, STATE_HOME)
+        tracker_states[entity_id] = state
+        _LOGGER.info(f"setting {entity_id} to {state}")
+
+        see_args = {
+            "dev_id": device,
+            "source_type": COMPONENT_DOMAIN,
+            "location_name": state,
+        }
         hass.async_create_task(async_see(**see_args))
+
+    async_track_state_change_event(hass, tracker_states.keys(), _state_changed)
+    hass.bus.async_listen("homeassistant_stop", _shutting_down)
 
     return True

--- a/custom_components/virtual/manifest.json
+++ b/custom_components/virtual/manifest.json
@@ -6,6 +6,6 @@
   "codeowners": [
     "@twrecked"
   ],
-  "version": "0.8.0a2",
+  "version": "0.8.0a3",
   "iot_class": "local_push"
 }

--- a/info.md
+++ b/info.md
@@ -7,8 +7,9 @@ Virtual components for testing Home Assistant systems.
 ### **Breaking Changes**
 
 I've added persistent support to `binary_sensor`, `fan`, `light`, `lock`,
-`sensor` and `switch`. The persistent saving of state is turned *on* by default.
-If you do not want this set `persistent: False` in the entity configuration.
+`sensor`, `switch` and `device_tracker`. The persistent saving of state is
+turned *on* by default. If you do not want this set `persistent: False` in the
+entity configuration.
 
 
 ## Features


### PR DESCRIPTION
Save/restore device tracker state across restarts.

I couldn't use `RestoreEntity` for this so has to add a state file into
`.storage`.

