### PR TITLE
Support stop and set_position for virtual cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ You only need one of `speed` or `speed_count`.
 - `direction`; if `True` then fan can run in 2 directions
 - `oscillate`; if `True` then fan can be set to oscillate
 
-### Covers _(in development)_
+### Covers
 
 To add a virtual cover use the following:
 
@@ -334,11 +334,13 @@ To add a virtual cover use the following:
   Test Cover:
   - platform: cover
     initial_value: 'closed'
+    open_close_duration: 10
+    open_close_tick: 1
 ```
 
-At the moment, only `open` (default `initial_value`) and `closed` states are
-supported and, therefore, only `cover.cover_open` and `cover.cover_close`
-services are available.
+Supports `open`, `close`, `stop` and `set_position`. Opening and closing of the cover is emulated with timed events, and the timing can be controlled with
+- `open_close_duration`: The time it take to go from fully open to fully closed, or back
+- `open_close_tick`: The update interval when opening and closing
 
 ### Device Tracking
 

--- a/custom_components/virtual/const.py
+++ b/custom_components/virtual/const.py
@@ -21,6 +21,8 @@ CONF_CLASS = "class"
 CONF_INITIAL_AVAILABILITY = "initial_availability"
 CONF_INITIAL_VALUE = "initial_value"
 CONF_NAME = "name"
+CONF_OPEN_CLOSE_DURATION = "open_close_duration"
+CONF_OPEN_CLOSE_TICK = "open_close_tick"
 CONF_PERSISTENT = "persistent"
 
 DEFAULT_AVAILABILITY = True

--- a/custom_components/virtual/cover.py
+++ b/custom_components/virtual/cover.py
@@ -109,12 +109,14 @@ class VirtualCover(VirtualEntity, CoverEntity):
         _LOGGER.info(f"opening {self.name}")
         self._attr_is_opening = True
         self._attr_is_closing = False
+        self._target_cover_position = 100
         self._tick()
 
     def close_cover(self, **kwargs: Any) -> None:
         _LOGGER.info(f"closing {self.name}")
         self._attr_is_opening = False
         self._attr_is_closing = True
+        self._target_cover_position = 0
         self._tick()
 
     def stop_cover(self, **kwargs: Any) -> None:
@@ -129,7 +131,7 @@ class VirtualCover(VirtualEntity, CoverEntity):
         else:
             self._attr_is_closed = True
             
-        self.async_write_ha_state()
+        self.schedule_update_ha_state()
         
     def set_cover_position(self, **kwargs: Any) -> None:
         _LOGGER.info(f"setting {self.name} position {kwargs['position']}")
@@ -141,7 +143,7 @@ class VirtualCover(VirtualEntity, CoverEntity):
         elif self._target_cover_position > self._attr_current_cover_position:
             self.open_cover()
 
-    def _update_cover_position(self, *args: Any) -> None:
+    async def _update_cover_position(self, *args: Any) -> None:
         if self._target_cover_position is not None:
             if self._attr_is_closing and self._attr_current_cover_position <= self._target_cover_position :
                 self.stop_cover()

--- a/custom_components/virtual/cover.py
+++ b/custom_components/virtual/cover.py
@@ -7,6 +7,7 @@ import logging
 import voluptuous as vol
 from typing import Any
 from collections.abc import Callable
+from datetime import datetime
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.cover import (
@@ -21,6 +22,7 @@ from homeassistant.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+from homeassistant.helpers.event import async_call_later
 
 from . import get_entity_configs
 from .const import *
@@ -35,9 +37,13 @@ DEFAULT_COVER_VALUE = "open"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(virtual_schema(DEFAULT_COVER_VALUE, {
     vol.Optional(CONF_CLASS): cv.string,
+    vol.Optional(CONF_OPEN_CLOSE_DURATION, default=10): cv.positive_int,
+    vol.Optional(CONF_OPEN_CLOSE_TICK, default=1): cv.positive_int,
 }))
 COVER_SCHEMA = vol.Schema(virtual_schema(DEFAULT_COVER_VALUE, {
     vol.Optional(CONF_CLASS): cv.string,
+    vol.Optional(CONF_OPEN_CLOSE_DURATION, default=10): cv.positive_int,
+    vol.Optional(CONF_OPEN_CLOSE_TICK, default=1): cv.positive_int,
 }))
 
 
@@ -65,8 +71,15 @@ class VirtualCover(VirtualEntity, CoverEntity):
         self._attr_device_class = config.get(CONF_CLASS)
         self._attr_supported_features = CoverEntityFeature(
             CoverEntityFeature.OPEN |
-            CoverEntityFeature.CLOSE
+            CoverEntityFeature.CLOSE |
+            CoverEntityFeature.STOP |
+            CoverEntityFeature.SET_POSITION
         )
+        self._attr_current_cover_position = 0
+        self._virtual_duration = config.get(CONF_OPEN_CLOSE_DURATION)
+        self._virtual_tick = config.get(CONF_OPEN_CLOSE_TICK)
+        self._virtual_operation_started = None
+        self._target_cover_position = None
 
         _LOGGER.info(f"VirtualCover: {self.name} created")
 
@@ -74,6 +87,10 @@ class VirtualCover(VirtualEntity, CoverEntity):
         super()._create_state(config)
 
         self._attr_is_closed = config.get(CONF_INITIAL_VALUE).lower() == STATE_CLOSED
+        if self._attr_is_closed:
+            self._attr_current_cover_position = 0
+        else:
+            self._attr_current_cover_position = 100
 
     def _restore_state(self, state, config):
         super()._restore_state(state, config)
@@ -90,8 +107,61 @@ class VirtualCover(VirtualEntity, CoverEntity):
 
     def open_cover(self, **kwargs: Any) -> None:
         _LOGGER.info(f"opening {self.name}")
-        self._attr_is_closed = False
+        self._attr_is_opening = True
+        self._attr_is_closing = False
+        self._tick()
 
     def close_cover(self, **kwargs: Any) -> None:
         _LOGGER.info(f"closing {self.name}")
-        self._attr_is_closed = True
+        self._attr_is_opening = False
+        self._attr_is_closing = True
+        self._tick()
+
+    def stop_cover(self, **kwargs: Any) -> None:
+        _LOGGER.info(f"stopping {self.name}")
+        self._virtual_operation_started = None
+        self._target_cover_position = None
+        self._attr_is_opening = False
+        self._attr_is_closing = False
+
+        if self._attr_current_cover_position > 0:
+            self._attr_is_closed = False
+        else:
+            self._attr_is_closed = True
+            
+        self.async_write_ha_state()
+        
+    def set_cover_position(self, **kwargs: Any) -> None:
+        _LOGGER.info(f"setting {self.name} position {kwargs['position']}")
+        self._target_cover_position = kwargs['position']
+        if self._target_cover_position == self._attr_current_cover_position:
+            return
+        elif self._target_cover_position < self._attr_current_cover_position:
+            self.close_cover()
+        elif self._target_cover_position > self._attr_current_cover_position:
+            self.open_cover()
+
+    def _update_cover_position(self, *args: Any) -> None:
+        if self._target_cover_position is not None:
+            if self._attr_is_closing and self._attr_current_cover_position <= self._target_cover_position :
+                self.stop_cover()
+            elif self._attr_is_opening and self._attr_current_cover_position >= self._target_cover_position:
+                self.stop_cover()
+
+        if self._virtual_operation_started is None:
+            return
+        
+        running_time_delta = datetime.now() - self._virtual_operation_started
+        percent_moved = int((running_time_delta.total_seconds() / self._virtual_duration)*100)
+
+        if self._attr_is_closing:
+            self._attr_current_cover_position = max(0, self._attr_current_cover_position - percent_moved)
+        elif self._attr_is_opening:
+            self._attr_current_cover_position = min(100, self._attr_current_cover_position + percent_moved)
+
+        self.async_write_ha_state()
+        self._tick()
+
+    def _tick(self):
+        self._virtual_operation_started = datetime.now()
+        async_call_later(self.hass, self._virtual_tick, self._update_cover_position)


### PR DESCRIPTION
Hey

I just found this project and it's been really helpful, but when creating som blueprints for a new cover entity I needed some more features from the virtual cover.

This PR adds support for "stop" and "set_position" for the virtual cover entity, and uses the `async_call_later` helper from homeassistant to fake a moving cover.

It also introduces two new config parameters for the virtual cover to control how "fast" the cover opens and closes