### PR TITLE
docs: fix names for "valve" services

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Test Valve:
   open_close_tick: 1
 ```
 
-Supports `open`, `close`, `stop` and `set_position`. Opening and closing of
+Supports `open_valve`, `close_valve`, `stop_valve` and `set_valve_position`. Opening and closing of
 the valve is emulated with timed events, and the timing can be controlled with
 - `open_close_duration`: The time it take to go from fully open to fully closed, or back
 - `open_close_tick`: The update interval when opening and closing


### PR DESCRIPTION
Names of `valve` services are incorrect.
The error seems to originate from official Docs.
There was an issue https://github.com/home-assistant/home-assistant.io/issues/34407 for errors in Docs, later it was fixed with https://github.com/home-assistant/home-assistant.io/pull/36606/.